### PR TITLE
feat : 자체 로그인 관련 기능 구현

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
+
+      - name: Start docker-compose services
+        run: |
+          docker-compose -f docker-compose.yml up -d
+
+      - name: Wait for services to be ready
+        run: sleep 15
 
       - name: Setup application.yml
         uses: microsoft/variable-substitution@v1
@@ -52,3 +60,7 @@ jobs:
           update-comment: true
           pass-emoji: ':green_circle:'
           fail-emoji: ':red_circle:'
+
+      - name: Stop docker-compose services
+        if: always()
+        run: docker-compose -f docker-compose.yml down

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,12 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      - name: Install docker-compose
+        run: |
+          sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+          docker-compose --version
+
       - name: Start docker-compose services
         run: |
           docker-compose -f docker-compose.yml up -d

--- a/build.gradle
+++ b/build.gradle
@@ -68,14 +68,15 @@ tasks.named('test') {
 }
 
 jacocoTestReport {
-     executionData(fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec"))
+//     executionData(fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec"))
 
     reports {
         html.required = true
         xml.required = true
     }
-    excludedClassFilesForReport(classDirectories)
+//    excludedClassFilesForReport(classDirectories)
 }
+
 
 private excludedClassFilesForReport(classDirectories) {
     classDirectories.setFrom(
@@ -83,7 +84,6 @@ private excludedClassFilesForReport(classDirectories) {
                 fileTree(dir: it, exclude: [
                         "**/common/**",
                         "**/dto/**",
-                        "**/*domain*/**",
                         "**/*Application*",
                         "**/controller/**",
                         "**/exception/**",

--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ tasks.named('test') {
 }
 
 jacocoTestReport {
-    // executionData(fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec"))
+     executionData(fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec"))
 
     reports {
         html.required = true

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ jacocoTestReport {
         html.required = true
         xml.required = true
     }
-//    excludedClassFilesForReport(classDirectories)
+    excludedClassFilesForReport(classDirectories)
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,11 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    // jwt
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/pokssak/gsg/common/config/SecurityConfig.java
+++ b/src/main/java/pokssak/gsg/common/config/SecurityConfig.java
@@ -1,0 +1,57 @@
+package pokssak.gsg.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import pokssak.gsg.common.filter.JwtAuthenticationFilter;
+import pokssak.gsg.common.filter.JwtExceptionFilter;
+import pokssak.gsg.common.jwt.JwtTokenProvider;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        http.
+            authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/v1/auth/**").permitAll()
+                .anyRequest().authenticated()
+            )
+
+            .headers(header -> header.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
+
+            .httpBasic(HttpBasicConfigurer::disable)
+
+            .csrf(CsrfConfigurer::disable)
+
+            .sessionManagement(sessionManagement ->
+                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            )
+            .addFilterBefore(new JwtExceptionFilter(), UsernamePasswordAuthenticationFilter.class)
+
+            .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
+                UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/pokssak/gsg/common/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/pokssak/gsg/common/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,41 @@
+package pokssak.gsg.common.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import pokssak.gsg.common.jwt.JwtTokenProvider;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+        throws ServletException, IOException {
+
+        String accessToken = resolveToken(request);
+
+        if (StringUtils.hasText(accessToken) && jwtTokenProvider.validateToken(accessToken)) {
+            Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest httpServletRequest) {
+        String bearerToken = httpServletRequest.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/pokssak/gsg/common/filter/JwtExceptionFilter.java
+++ b/src/main/java/pokssak/gsg/common/filter/JwtExceptionFilter.java
@@ -16,7 +16,6 @@ import pokssak.gsg.common.exception.ErrorResponse;
 @RequiredArgsConstructor
 public class JwtExceptionFilter extends OncePerRequestFilter {
 
-    private final ObjectMapper objectMapper;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -39,7 +38,7 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
 
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(errorCode.getHttpStatus().value());
-        response.getWriter().write(objectMapper.writeValueAsString(ApiResponse.fail(errorResponse)));
+        response.getWriter().write(new ObjectMapper().writeValueAsString(ApiResponse.fail(errorResponse)));
         response.getWriter().flush();
         response.getWriter().close();
     }

--- a/src/main/java/pokssak/gsg/common/filter/JwtExceptionFilter.java
+++ b/src/main/java/pokssak/gsg/common/filter/JwtExceptionFilter.java
@@ -1,0 +1,46 @@
+package pokssak.gsg.common.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.filter.OncePerRequestFilter;
+import pokssak.gsg.common.dto.ApiResponse;
+import pokssak.gsg.common.exception.CustomException;
+import pokssak.gsg.common.exception.ErrorCode;
+import pokssak.gsg.common.exception.ErrorResponse;
+
+@RequiredArgsConstructor
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+        throws ServletException, IOException {
+
+        try {
+            filterChain.doFilter(request, response);
+        } catch (CustomException e) {
+            sendErrorResponse(response, e.getErrorCode());
+        }
+
+    }
+
+    private void sendErrorResponse(HttpServletResponse response, ErrorCode errorCode)
+        throws IOException {
+
+        ErrorResponse errorResponse = ErrorResponse.builder()
+            .message(errorCode.getMessage())
+            .build();
+
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.getWriter().write(objectMapper.writeValueAsString(ApiResponse.fail(errorResponse)));
+        response.getWriter().flush();
+        response.getWriter().close();
+    }
+}

--- a/src/main/java/pokssak/gsg/common/jwt/JwtErrorCode.java
+++ b/src/main/java/pokssak/gsg/common/jwt/JwtErrorCode.java
@@ -1,0 +1,28 @@
+package pokssak.gsg.common.jwt;
+
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import pokssak.gsg.common.exception.ErrorCode;
+
+@AllArgsConstructor
+public enum JwtErrorCode implements ErrorCode {
+
+    EXPIRE_ERROR(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰 입니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 JWT 토큰 입니다."),
+    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "지원하지 않는 형식의 토큰 입니다."),
+    NOT_FOUND_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 비어있습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}
+

--- a/src/main/java/pokssak/gsg/common/jwt/JwtTokenDto.java
+++ b/src/main/java/pokssak/gsg/common/jwt/JwtTokenDto.java
@@ -1,0 +1,8 @@
+package pokssak.gsg.common.jwt;
+
+public record JwtTokenDto(String accessToken, String refreshToken) {
+
+    public static JwtTokenDto of(String accessToken, String refreshToken) {
+        return new JwtTokenDto(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/pokssak/gsg/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/pokssak/gsg/common/jwt/JwtTokenProvider.java
@@ -26,8 +26,8 @@ public class JwtTokenProvider {
     private final Key key;
     private final UserDetailsService userDetailsService;
 
-    public JwtTokenProvider(@Value("${security.jwt.secret}") String secretKey,
-                            @Value("${security.jwt.expire-seconds}") long tokenExpireSeconds,
+    public JwtTokenProvider(@Value("${jwt.secret}") String secretKey,
+                            @Value("${jwt.token-expire-seconds}") long tokenExpireSeconds,
                             UserDetailsService userDetailsService) {
         this.tokenExpireSeconds = tokenExpireSeconds;
         byte[] keyBytes = Decoders.BASE64.decode(secretKey);
@@ -59,7 +59,7 @@ public class JwtTokenProvider {
     public Authentication getAuthentication(String accessToken) {
         String email = getClaims(accessToken).getSubject();
         UserDetails userDetails = userDetailsService.loadUserByUsername(email);
-        return new UsernamePasswordAuthenticationToken(userDetails, "");
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
 
     public Claims getClaims(String token) {

--- a/src/main/java/pokssak/gsg/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/pokssak/gsg/common/jwt/JwtTokenProvider.java
@@ -1,0 +1,88 @@
+package pokssak.gsg.common.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import java.security.Key;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import pokssak.gsg.common.exception.CustomException;
+
+@Component
+public class JwtTokenProvider {
+
+    private final long tokenExpireSeconds;
+    private final Key key;
+    private final UserDetailsService userDetailsService;
+
+    public JwtTokenProvider(@Value("${security.jwt.secret}") String secretKey,
+                            @Value("${security.jwt.expire-seconds}") long tokenExpireSeconds,
+                            UserDetailsService userDetailsService) {
+        this.tokenExpireSeconds = tokenExpireSeconds;
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.userDetailsService = userDetailsService;
+    }
+
+
+    public JwtTokenDto createToken(String email) {
+        long now = (new Date()).getTime();
+        Date accessTokenExpireTime = new Date(now + tokenExpireSeconds);
+        Date refreshTokenExpireTime = new Date(now + (tokenExpireSeconds * 2 * 30));
+
+        String accessToken = Jwts.builder()
+            .setSubject(email)
+            .signWith(key, SignatureAlgorithm.HS512)
+            .setExpiration(accessTokenExpireTime)
+            .compact();
+
+        String refreshToken = Jwts.builder()
+            .setSubject(email)
+            .signWith(key, SignatureAlgorithm.HS512)
+            .setExpiration(refreshTokenExpireTime)
+            .compact();
+
+        return JwtTokenDto.of(accessToken, refreshToken);
+    }
+
+    public Authentication getAuthentication(String accessToken) {
+        String email = getClaims(accessToken).getSubject();
+        UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+        return new UsernamePasswordAuthenticationToken(userDetails, "");
+    }
+
+    public Claims getClaims(String token) {
+        return Jwts
+            .parserBuilder()
+            .setSigningKey(key)
+            .build()
+            .parseClaimsJws(token)
+            .getBody();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (SignatureException | MalformedJwtException e) {
+            throw new CustomException(JwtErrorCode.INVALID_TOKEN);
+        } catch (ExpiredJwtException e) {
+            throw new CustomException(JwtErrorCode.EXPIRE_ERROR);
+        } catch (UnsupportedJwtException e) {
+            throw new CustomException(JwtErrorCode.UNSUPPORTED_TOKEN);
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(JwtErrorCode.NOT_FOUND_TOKEN);
+        }
+    }
+}

--- a/src/main/java/pokssak/gsg/domain/user/controller/AuthController.java
+++ b/src/main/java/pokssak/gsg/domain/user/controller/AuthController.java
@@ -1,0 +1,32 @@
+package pokssak.gsg.domain.user.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import pokssak.gsg.common.dto.ApiResponse;
+import pokssak.gsg.domain.user.dto.LoginRequestDto;
+import pokssak.gsg.domain.user.dto.SignupRequestDto;
+import pokssak.gsg.domain.user.service.AuthService;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("signup")
+    public ResponseEntity<?> localSignup(@RequestBody SignupRequestDto signupRequestDto) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ApiResponse.ok(authService.localSignup(signupRequestDto)));
+    }
+
+    @PostMapping("login")
+    public ResponseEntity<?> localLogin(@RequestBody LoginRequestDto loginRequestDto) {
+        return ResponseEntity.ok(ApiResponse.ok(authService.localLogin(loginRequestDto)));
+    }
+}

--- a/src/main/java/pokssak/gsg/domain/user/dto/LoginRequestDto.java
+++ b/src/main/java/pokssak/gsg/domain/user/dto/LoginRequestDto.java
@@ -1,0 +1,5 @@
+package pokssak.gsg.domain.user.dto;
+
+public record LoginRequestDto(String email, String password) {
+
+}

--- a/src/main/java/pokssak/gsg/domain/user/dto/SignupRequestDto.java
+++ b/src/main/java/pokssak/gsg/domain/user/dto/SignupRequestDto.java
@@ -1,0 +1,5 @@
+package pokssak.gsg.domain.user.dto;
+
+public record SignupRequestDto(String email, String password, String nickname) {
+
+}

--- a/src/main/java/pokssak/gsg/domain/user/entity/User.java
+++ b/src/main/java/pokssak/gsg/domain/user/entity/User.java
@@ -8,15 +8,20 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.Collection;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 import pokssak.gsg.common.entity.BaseEntity;
+import pokssak.gsg.common.exception.CustomException;
 import pokssak.gsg.domain.bookmark.entity.Bookmark;
 import pokssak.gsg.domain.review.entity.Review;
+import pokssak.gsg.domain.user.exception.UserErrorCode;
 
 @Table(name = "users")
 @Builder
@@ -24,7 +29,7 @@ import pokssak.gsg.domain.review.entity.Review;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class User extends BaseEntity {
+public class User extends BaseEntity implements UserDetails {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -43,4 +48,20 @@ public class User extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private JoinType joinType;
+
+    public void validatePassword(String password) {
+        if (!password.equals(this.password)) {
+            throw new CustomException(UserErrorCode.INCORRECT_PASSWORD);
+        }
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of();
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
 }

--- a/src/main/java/pokssak/gsg/domain/user/entity/User.java
+++ b/src/main/java/pokssak/gsg/domain/user/entity/User.java
@@ -1,6 +1,7 @@
 package pokssak.gsg.domain.user.entity;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -40,6 +41,6 @@ public class User extends BaseEntity {
     @OneToMany
     private List<Review> reviews;
 
-    @Enumerated
+    @Enumerated(EnumType.STRING)
     private JoinType joinType;
 }

--- a/src/main/java/pokssak/gsg/domain/user/entity/User.java
+++ b/src/main/java/pokssak/gsg/domain/user/entity/User.java
@@ -60,8 +60,8 @@ public class User extends BaseEntity {
     @Override
     public String getUsername() {
         return email;
+    }
       
-
     public void updateProfile(String nickName, String imageUrl) {
         this.nickName = nickName;
         this.imageUrl = imageUrl;

--- a/src/main/java/pokssak/gsg/domain/user/entity/User.java
+++ b/src/main/java/pokssak/gsg/domain/user/entity/User.java
@@ -46,12 +46,6 @@ public class User extends BaseEntity implements UserDetails{
 
     private boolean isDeleted = false;
 
-    public void validatePassword(String password) {
-        if (!password.equals(this.password)) {
-            throw new CustomException(UserErrorCode.INCORRECT_PASSWORD);
-        }
-    }
-
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return List.of();

--- a/src/main/java/pokssak/gsg/domain/user/entity/User.java
+++ b/src/main/java/pokssak/gsg/domain/user/entity/User.java
@@ -1,6 +1,6 @@
 package pokssak.gsg.domain.user.entity;
 
-
+import java.util.*;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import jakarta.persistence.*;

--- a/src/main/java/pokssak/gsg/domain/user/entity/User.java
+++ b/src/main/java/pokssak/gsg/domain/user/entity/User.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 @SQLDelete(sql = "UPDATE users SET is_deleted = true WHERE id = ?")
 @Where(clause = "is_deleted = false")
-public class User extends BaseEntity {
+public class User extends BaseEntity implements UserDetails{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/pokssak/gsg/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/pokssak/gsg/domain/user/exception/UserErrorCode.java
@@ -7,7 +7,9 @@ import pokssak.gsg.common.exception.ErrorCode;
 @AllArgsConstructor
 public enum UserErrorCode implements ErrorCode {
 
-    NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 계정입니다.");
+    NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 계정입니다."),
+    INCORRECT_PASSWORD(HttpStatus.UNAUTHORIZED, "올바르지 않은 비밀번호 입니다."),
+    USER_EMAIL_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 이메일 입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/pokssak/gsg/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/pokssak/gsg/domain/user/exception/UserErrorCode.java
@@ -9,7 +9,8 @@ public enum UserErrorCode implements ErrorCode {
 
     NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 계정입니다."),
     INCORRECT_PASSWORD(HttpStatus.UNAUTHORIZED, "올바르지 않은 비밀번호 입니다."),
-    ALREADY_ACTIVE(HttpStatus.BAD_REQUEST, "이미 복구된 계정입니다.");
+    ALREADY_ACTIVE(HttpStatus.BAD_REQUEST, "이미 복구된 계정입니다."),
+    USER_EMAIL_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 이메일 입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/pokssak/gsg/domain/user/repository/UserRepository.java
+++ b/src/main/java/pokssak/gsg/domain/user/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package pokssak.gsg.domain.user.repository;
 
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import pokssak.gsg.domain.user.entity.User;
@@ -8,4 +9,7 @@ import pokssak.gsg.domain.user.entity.User;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
+    Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/pokssak/gsg/domain/user/service/AuthService.java
+++ b/src/main/java/pokssak/gsg/domain/user/service/AuthService.java
@@ -1,0 +1,58 @@
+package pokssak.gsg.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import pokssak.gsg.common.exception.CustomException;
+import pokssak.gsg.common.jwt.JwtTokenDto;
+import pokssak.gsg.common.jwt.JwtTokenProvider;
+import pokssak.gsg.domain.user.dto.LoginRequestDto;
+import pokssak.gsg.domain.user.dto.SignupRequestDto;
+import pokssak.gsg.domain.user.entity.JoinType;
+import pokssak.gsg.domain.user.entity.User;
+import pokssak.gsg.domain.user.exception.UserErrorCode;
+import pokssak.gsg.domain.user.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public JwtTokenDto localSignup(SignupRequestDto signupRequestDto) {
+
+        if (userRepository.existsByEmail(signupRequestDto.email())) {
+            throw new CustomException(UserErrorCode.USER_EMAIL_ALREADY_EXIST);
+        }
+
+        User user = User.builder()
+            .password(passwordEncoder.encode(signupRequestDto.password()))
+            .nickName(signupRequestDto.nickname())
+            .email(signupRequestDto.email())
+            .joinType(JoinType.LOCAL)
+            .build();
+
+        userRepository.save(user);
+
+        JwtTokenDto token = jwtTokenProvider.createToken(user.getEmail());
+
+        // TODO : refresh token store in redis
+        return token;
+    }
+
+    public JwtTokenDto localLogin(LoginRequestDto loginRequestDto) {
+        User user = userRepository.findByEmail(loginRequestDto.email())
+            .orElseThrow(() -> new CustomException(UserErrorCode.NOT_FOUND));
+
+        if (!passwordEncoder.matches(loginRequestDto.password(), user.getPassword())) {
+            throw new CustomException(UserErrorCode.INCORRECT_PASSWORD);
+        }
+        
+        JwtTokenDto token = jwtTokenProvider.createToken(user.getEmail());
+
+        // TODO : refresh token store in redis
+        return token;
+    }
+}

--- a/src/main/java/pokssak/gsg/domain/user/service/CustomUserDetailsService.java
+++ b/src/main/java/pokssak/gsg/domain/user/service/CustomUserDetailsService.java
@@ -1,0 +1,24 @@
+package pokssak.gsg.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import pokssak.gsg.common.exception.CustomException;
+import pokssak.gsg.domain.user.entity.User;
+import pokssak.gsg.domain.user.exception.UserErrorCode;
+import pokssak.gsg.domain.user.repository.UserRepository;
+
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public User loadUserByUsername(String username) throws UsernameNotFoundException {
+        return userRepository.findByEmail(username)
+            .orElseThrow(() -> new CustomException(UserErrorCode.NOT_FOUND));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    default: local
+    default: dev
 
   jpa:
     open-in-view: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    default: dev
+    default: local
 
   jpa:
     open-in-view: false
@@ -13,3 +13,7 @@ spring:
   elasticsearch:
     connection-timeout: 3s
     uris: ${elasticsearch.host:localhost}
+
+jwt:
+  secret: 5e7ae888548f2aef0935d46dad396c76031e333eb024c83a849cbadae7bb4aba3a3273ac5b108262b9f2d973fd36d300d2347b9826e7359a2bbec1df2c7fb05145ef8e5a640107ee540539d5069339b583acffbe381f272ccddb1ea8e7c3d39dcd7fb4212209d55fb2be03a012ede1ad2dfa868be1b956bd81f01b1b424786f2
+  token-expire-seconds: 43200000 # 12 시간

--- a/src/test/java/pokssak/gsg/domain/user/service/AuthServiceTest.java
+++ b/src/test/java/pokssak/gsg/domain/user/service/AuthServiceTest.java
@@ -1,0 +1,75 @@
+package pokssak.gsg.domain.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import pokssak.gsg.common.jwt.JwtTokenDto;
+import pokssak.gsg.common.jwt.JwtTokenProvider;
+import pokssak.gsg.domain.user.dto.LoginRequestDto;
+import pokssak.gsg.domain.user.dto.SignupRequestDto;
+import pokssak.gsg.domain.user.entity.User;
+import pokssak.gsg.domain.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+
+    @InjectMocks
+    AuthService authService;
+
+    @Mock
+    UserRepository userRepository;
+
+    @Mock
+    JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    PasswordEncoder passwordEncoder;
+
+
+    @Test
+    void localSignupTest() {
+        String email = "example@google.com";
+        when(userRepository.existsByEmail(email)).thenReturn(false);
+        when(passwordEncoder.encode("password")).thenReturn("password");
+        when(jwtTokenProvider.createToken(email)).thenReturn(new JwtTokenDto("accessToken", "refreshToken"));
+
+        SignupRequestDto signupRequestDto = new SignupRequestDto(email, "password", "nickname");
+        JwtTokenDto jwtTokenDto = authService.localSignup(signupRequestDto);
+
+        verify(userRepository, times(1)).save(any());
+        assertThat(jwtTokenDto.accessToken()).isNotNull();
+        assertThat(jwtTokenDto.refreshToken()).isNotNull();
+    }
+
+    @Test
+    void localLoginTest() {
+        User user = User.builder()
+            .email("example@google.com")
+            .password("password")
+            .build();
+
+        String email = "example@google.com";
+
+        LoginRequestDto loginRequestDto = new LoginRequestDto(email, "password");
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(loginRequestDto.password(), user.getPassword())).thenReturn(true);
+        when(jwtTokenProvider.createToken(email)).thenReturn(new JwtTokenDto("accessToken", "refreshToken"));
+
+        JwtTokenDto jwtTokenDto = authService.localLogin(loginRequestDto);
+        assertThat(jwtTokenDto.accessToken()).isNotNull();
+        assertThat(jwtTokenDto.refreshToken()).isNotNull();
+    }
+
+}

--- a/src/test/java/pokssak/gsg/domain/user/service/CustomUserDetailsServiceTest.java
+++ b/src/test/java/pokssak/gsg/domain/user/service/CustomUserDetailsServiceTest.java
@@ -1,0 +1,38 @@
+package pokssak.gsg.domain.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import pokssak.gsg.domain.user.entity.User;
+import pokssak.gsg.domain.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class CustomUserDetailsServiceTest {
+
+    @InjectMocks
+    CustomUserDetailsService customUserDetailsService;
+
+    @Mock
+    UserRepository userRepository;
+
+    @Test
+    void testLoadUserByUsername() {
+        String email = "example@google.com";
+        User user = User.builder()
+            .email(email)
+            .build();
+
+        Mockito.when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+
+        User find = customUserDetailsService.loadUserByUsername(email);
+
+        assertThat(find.getUsername()).isEqualTo(email);
+    }
+
+}


### PR DESCRIPTION
### 🔥 PR 개요  
- 자체 로그인/회원가입 추가

### ✅ 주요 변경 사항  
- 자체 로그인/회원가입 기능을 jwt 토큰을 이용해서 구현

### 🔄 관련 이슈  

- https://github.com/pok-ssak/cafe-gamsugwang-be/issues/6

### 📌 추가 정보  
- 현재 Refresh Token을 발급을 하지만 저장을 하거나 사용하는 로직이 존재 하지 않습니다. Oauth 관련 기능을 구현하면서 로그아웃등의 기능을 구현 할때 같이 구현 하도록 하겠습니다.
