### PR TITLE
fix : swagger 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation 'io.github.cdimascio:dotenv-java:3.0.0'
 
     // swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
     // logging
     implementation "com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.11.0"


### PR DESCRIPTION
### 🔥 PR 개요  

- swagger 버전 문제로 swagger가 생성이 안되는 문제 해결

### ✅ 주요 변경 사항  

- `'org.springdoc:springdoc-openapi-starter-webmvc-ui'`의 버전을 `2.8.6` &rightarrow; `2.7.0`으로 변경

### 🔄 관련 이슈  
연관된 이슈가 있으면 링크를 추가해주세요.  

### 📌 추가 정보  
테스트 방법, 참고할 사항 등을 포함해주세요.  
