### PR TITLE
refactor: userdetails에 유저와 유저키워드까지 함께 가져오도록 수정

### DIFF
--- a/src/main/java/pokssak/gsg/domain/cafe/service/CafeESClient.java
+++ b/src/main/java/pokssak/gsg/domain/cafe/service/CafeESClient.java
@@ -14,14 +14,12 @@ import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.SearchHits;
-import org.springframework.data.elasticsearch.core.geo.GeoPoint;
 import org.springframework.data.elasticsearch.core.query.FetchSourceFilter;
 import org.springframework.stereotype.Service;
 import pokssak.gsg.domain.cafe.dto.AutoCompleteResponse;
 import pokssak.gsg.domain.cafe.dto.RecommendResponse;
 import pokssak.gsg.domain.cafe.dto.SearchCafeResponse;
 import pokssak.gsg.domain.cafe.entity.CafeDocument;
-import pokssak.gsg.domain.user.entity.UserKeyword;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,7 +27,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class CafeSearchService {
+public class CafeESClient {
     private final ElasticsearchOperations operations;
     private final EmbeddingModel embeddingModel;
 

--- a/src/main/java/pokssak/gsg/domain/user/entity/User.java
+++ b/src/main/java/pokssak/gsg/domain/user/entity/User.java
@@ -46,7 +46,7 @@ public class User extends BaseEntity implements UserDetails {
     private String imageUrl;
     private String oauthPlatformId;
 
-    @OneToMany
+    @OneToMany(mappedBy = "user")
     private List<UserKeyword> userKeywords;
     @OneToMany
     private List<Bookmark> bookmarks;

--- a/src/main/java/pokssak/gsg/domain/user/repository/UserRepository.java
+++ b/src/main/java/pokssak/gsg/domain/user/repository/UserRepository.java
@@ -20,4 +20,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByIdIncludeDeleted(@Param("userId") Long userId);
 
     Optional<User> findByOauthPlatformIdAndJoinType(String platformId, JoinType joinType);
+
+    @Query("select u from User u left join fetch u.userKeywords where u.id = :userid")
+    Optional<User> findByIdWithKeywords(Long userid);
+
+
 }

--- a/src/main/java/pokssak/gsg/domain/user/service/CustomUserDetailsService.java
+++ b/src/main/java/pokssak/gsg/domain/user/service/CustomUserDetailsService.java
@@ -18,7 +18,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public User loadUserByUsername(String username) throws UsernameNotFoundException {
-        return userRepository.findById(Long.valueOf(username))
+        return userRepository.findByIdWithKeywords(Long.valueOf(username))
             .orElseThrow(() -> new CustomException(UserErrorCode.NOT_FOUND));
     }
 }

--- a/src/test/java/pokssak/gsg/domain/user/service/CustomUserDetailsServiceTest.java
+++ b/src/test/java/pokssak/gsg/domain/user/service/CustomUserDetailsServiceTest.java
@@ -32,7 +32,7 @@ class CustomUserDetailsServiceTest {
             .email(email)
             .build();
 
-        Mockito.when(userRepository.findById(id)).thenReturn(Optional.of(user));
+        Mockito.when(userRepository.findByIdWithKeywords(id)).thenReturn(Optional.of(user));
 
         User find = customUserDetailsService.loadUserByUsername(id.toString());
 


### PR DESCRIPTION
### 🔥 PR 개요  
osiv설정 off로 컨트롤러에서 로그인 된 유저 객체를 가져올때 연관관계에 있는 다른 필드들은 가져올 수 없음

### ✅ 주요 변경 사항  
userdetails에 유저와 유저키워드까지 함께 가져오도록 수정

